### PR TITLE
Eclipse 2022-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
-    <version>2.3.0</version>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>2.7.4</version>
   </extension>
 </extensions>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/bundles/tools.vitruv.adapters.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adapters.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Eclipse Tool Adapter
 Bundle-SymbolicName: tools.vitruv.adapters.eclipse;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.eclipse
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.vitruv.adapters.eclipse.Activator

--- a/bundles/tools.vitruv.adapters.eclipse/plugin.xml
+++ b/bundles/tools.vitruv.adapters.eclipse/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension-point id="builder" name="Vitruv Eclipse Project Builder" schema="schema/builder.exsd"/>
+   <extension-point id="projectbuilder" name="Vitruv Eclipse Project Builder" schema="schema/builder.exsd"/>
 
 </plugin>

--- a/bundles/tools.vitruv.adapters.eclipse/schema/builder.exsd
+++ b/bundles/tools.vitruv.adapters.eclipse/schema/builder.exsd
@@ -3,7 +3,7 @@
 <schema targetNamespace="tools.vitruv.adapters.eclipse" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="tools.vitruv.adapters.eclipse" id="builder" name="Vitruv Eclipse Project Builder"/>
+         <meta.schema plugin="tools.vitruv.adapters.eclipse" id="projectbuilder" name="Vitruv Eclipse Project Builder"/>
       </appinfo>
       <documentation>
          Defines a VitruvEclipseProjectBuilder to use for a specific kind of monitoring changes.
@@ -94,7 +94,7 @@
 &lt;/extension&gt;
 &lt;extension
       name=&quot;Vitruv EMF Project Builder&quot;
-      point=&quot;tools.vitruv.adapters.eclipse.builder&quot;&gt;
+      point=&quot;tools.vitruv.adapters.eclipse.projectbuilder&quot;&gt;
    &lt;assignment
      name=&quot;Vitruv EMF Project Builder&quot; 
         builderId=&quot;tools.vitruv.adapters.emf.builder.id&quot;&gt;

--- a/bundles/tools.vitruv.adapters.emf/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adapters.emf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv EMF Tool Adapter
 Bundle-SymbolicName: tools.vitruv.adapters.emf;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.emf
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/bundles/tools.vitruv.adapters.emf/plugin.xml
+++ b/bundles/tools.vitruv.adapters.emf/plugin.xml
@@ -12,7 +12,7 @@
    </extension>
    <extension
          name="Vitruv EMF Project Builder"
-         point="tools.vitruv.adapters.eclipse.builder">
+         point="tools.vitruv.adapters.eclipse.projectbuilder">
       <assignment
       		name="Vitruv EMF Project Builder" 
             builderId="tools.vitruv.adapters.emf.builder.id">

--- a/bundles/tools.vitruv.adaptors.eclipse.vsum/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adaptors.eclipse.vsum/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Eclipse Adapter for V-SUM Creation
 Bundle-SymbolicName: tools.vitruv.adapters.eclipse.vsum;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.eclipse.vsum
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Activator: tools.vitruv.adapters.eclipse.vsum.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/features/tools.vitruv.adapters.eclipse.feature/feature.xml
+++ b/features/tools.vitruv.adapters.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.adapters.eclipse.feature"
       label="%featureName"
-      version="2.1.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.adapters.emf.feature/feature.xml
+++ b/features/tools.vitruv.adapters.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.adapters.emf.feature"
       label="%featureName"
-      version="2.1.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>adapters-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>releng/tools.vitruv.adapters.parent</relativePath>
 	</parent>
 	<artifactId>tools.vitruv</artifactId>

--- a/releng/tools.vitruv.adapters.parent/pom.xml
+++ b/releng/tools.vitruv.adapters.parent/pom.xml
@@ -9,7 +9,7 @@
 		<version>2.0.0</version>
 	</parent>
 	<artifactId>adapters-parent</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<properties>

--- a/releng/tools.vitruv.adapters.parent/pom.xml
+++ b/releng/tools.vitruv.adapters.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.2</version>
 	</parent>
 	<artifactId>adapters-parent</artifactId>
 	<version>3.0.0-SNAPSHOT</version>

--- a/releng/tools.vitruv.adapters.parent/pom.xml
+++ b/releng/tools.vitruv.adapters.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.4.1</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>adapters-parent</artifactId>
 	<version>2.1.0-SNAPSHOT</version>

--- a/releng/tools.vitruv.adapters.updatesite/category.xml
+++ b/releng/tools.vitruv.adapters.updatesite/category.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.adapters.eclipse.feature_2.1.0.qualifier.jar" id="tools.vitruv.adapters.eclipse.feature" version="2.1.0.qualifier">
+   <feature url="features/tools.vitruv.adapters.eclipse.feature_3.0.0.qualifier.jar" id="tools.vitruv.adapters.eclipse.feature" version="3.0.0.qualifier">
       <category name="Vitruv Tool Adapters"/>
    </feature>
-   <feature id="tools.vitruv.adapters.eclipse.feature.source" version="2.1.0.qualifier">
+   <feature id="tools.vitruv.adapters.eclipse.feature.source" version="3.0.0.qualifier">
       <category name="Vitruv Tool Adapters"/>
    </feature>
-   <feature url="features/tools.vitruv.adapters.emf.feature_2.1.0.qualifier.jar" id="tools.vitruv.adapters.emf.feature" version="2.1.0.qualifier">
+   <feature url="features/tools.vitruv.adapters.emf.feature_3.0.0.qualifier.jar" id="tools.vitruv.adapters.emf.feature" version="3.0.0.qualifier">
       <category name="Vitruv Tool Adapters"/>
    </feature>
-   <feature id="tools.vitruv.adapters.emf.feature.source" version="2.1.0.qualifier">
+   <feature id="tools.vitruv.adapters.emf.feature.source" version="3.0.0.qualifier">
       <category name="Vitruv Tool Adapters"/>
    </feature>
    <category-def name="Vitruv Tool Adapters" label="Vitruv Tool Adapters">

--- a/releng/tools.vitruv.adapters.updatesite/pom.xml
+++ b/releng/tools.vitruv.adapters.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>adapters-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.adapters.parent</relativePath>
 	</parent>
 	

--- a/tests/tools.vitruv.adapters.emf.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.adapters.emf.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv EMF Adapter Tests
 Bundle-Vendor: vitruv.tools
 Bundle-SymbolicName: tools.vitruv.adapters.emf.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.emf.tests
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.testutils.vsum,

--- a/tests/tools.vitruv.adapters.emf.tests/pom.xml
+++ b/tests/tools.vitruv.adapters.emf.tests/pom.xml
@@ -7,12 +7,12 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>tests</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>..\.polyglot.pom.tycho</relativePath>
   </parent>
 
   <artifactId>tools.vitruv.adapters.emf.tests</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <name>[test-bundle] Vitruv EMF Adapter Tests</name>
 

--- a/tests/tools.vitruv.adapters.emf.tests/pom.xml
+++ b/tests/tools.vitruv.adapters.emf.tests/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tests</artifactId>
+    <version>2.1.0-SNAPSHOT</version>
+    <relativePath>..\.polyglot.pom.tycho</relativePath>
+  </parent>
+
+  <artifactId>tools.vitruv.adapters.emf.tests</artifactId>
+  <version>2.1.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+  <name>[test-bundle] Vitruv EMF Adapter Tests</name>
+
+  <organization>
+    <name>vitruv.tools</name>
+  </organization>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>integration-test</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Improve dependencies for Eclipse 2022-06 updating parent POM to 2.0.0. New parent POM requires platform tests to be explicitly configured, as tests are run as plain JUnit tests by default.

Due to breaking changes, we bump the development version from 2.1.0 to 3.0.0