### PR TITLE
Enable CI actions for all 3 major OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,7 +45,7 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Publish Nightly Update Site
-        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}
@@ -52,7 +56,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish Release Update Site
-        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}


### PR DESCRIPTION
This PR adds support to run the validation GitHub Actions on all major OS (Linux, Windows, macOS).
Releases are still built and released on Ubuntu only.

⚠️ Before merging this, the branch protection rules need to be adjusted to the modified jobs ⚠️