### PR TITLE
Migrate to Eclipse 2022-12 and Java 17

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.4</version>
+    <version>3.0.0</version>
   </extension>
 </extensions>

--- a/bundles/tools.vitruv.adapters.eclipse/.classpath
+++ b/bundles/tools.vitruv.adapters.eclipse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.adapters.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adapters.eclipse/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Eclipse Tool Adapter
 Bundle-SymbolicName: tools.vitruv.adapters.eclipse;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.eclipse
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.vitruv.adapters.eclipse.Activator
 Require-Bundle: org.apache.log4j,

--- a/bundles/tools.vitruv.adapters.emf/.classpath
+++ b/bundles/tools.vitruv.adapters.emf/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.adapters.emf/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adapters.emf/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv EMF Tool Adapter
 Bundle-SymbolicName: tools.vitruv.adapters.emf;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.emf
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.core.commands,

--- a/bundles/tools.vitruv.adaptors.eclipse.vsum/.classpath
+++ b/bundles/tools.vitruv.adaptors.eclipse.vsum/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/bundles/tools.vitruv.adaptors.eclipse.vsum/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.adaptors.eclipse.vsum/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  tools.vitruv.adapters.eclipse,
  org.apache.log4j,
  edu.kit.ipd.sdq.commons.util.eclipse
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.adapters.eclipse.vsum,

--- a/releng/tools.vitruv.adapters.parent/pom.xml
+++ b/releng/tools.vitruv.adapters.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1</version>
 	</parent>
 	<artifactId>adapters-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>
@@ -33,17 +33,17 @@
 		<repository>
 			<id>Demo Metamodels</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/${sdq.demometamodels.version}</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/${sdq.commons.version}</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/latest/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/${sdq.xannotations.version}</url>
 		</repository>
 	</repositories>
 

--- a/releng/tools.vitruv.adapters.parent/pom.xml
+++ b/releng/tools.vitruv.adapters.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 	</parent>
 	<artifactId>adapters-parent</artifactId>
 	<version>3.0.1-SNAPSHOT</version>

--- a/tests/tools.vitruv.adapters.emf.tests/.classpath
+++ b/tests/tools.vitruv.adapters.emf.tests/.classpath
@@ -16,7 +16,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/tests/tools.vitruv.adapters.emf.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.adapters.emf.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: vitruv.tools
 Bundle-SymbolicName: tools.vitruv.adapters.emf.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.adapters.emf.tests
 Bundle-Version: 3.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.testutils.vsum,
  org.junit.jupiter.api,


### PR DESCRIPTION
Updates dependencies to Eclipse 2022-12 and migrates to JavaSE-17.
Pins SDQ dependency versions to version specified in parent pom.